### PR TITLE
Benchmarks for dynamic variable access

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,12 @@ jobs:
     - name: Check code formatting
       run: cargo fmt -- --check
     - name: Run static analysis
-      run: cargo clippy --all-targets
+      run: cargo clippy
     - name: Run normal build
       run: cargo build
+    - name: Compile testing dependencies
+      run: cargo test --no-run
+    - name: Run static analysis on tests
+      run: cargo clippy --all-targets
     - name: Run unit-test suite
       run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ license = "MIT"
 [badges]
 travis-ci = { repository = "ilammy/fluid-let" }
 appveyor = { repository = "ilammy/fluid-let" }
+
+[dev-dependencies]
+criterion = "0.3.0"
+
+[[bench]]
+name = "fluid-let"
+harness = false

--- a/benches/fluid-let.rs
+++ b/benches/fluid-let.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2019, ilammy
+// Licensed under MIT license (see LICENSE)
+
+use criterion::*;
+
+use fluid_let::fluid_let;
+
+fn get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fluid_let");
+    group.bench_function(BenchmarkId::new("get", "dynamic"), |b| {
+        fluid_let!(static COUNTER: i32);
+        let mut total = 0;
+        COUNTER.set(1, || {
+            b.iter(|| COUNTER.get(|value| total += value.unwrap_or(&0)));
+        });
+    });
+    group.bench_function(BenchmarkId::new("get", "static"), |b| {
+        static mut COUNTER: Option<&i32> = None;
+        let mut total = 0;
+        unsafe {
+            COUNTER = Some(&1);
+            b.iter(|| total += COUNTER.unwrap_or(&0));
+            COUNTER = None;
+        }
+    });
+    group.finish();
+}
+
+fn set(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fluid_let");
+    group.bench_function(BenchmarkId::new("set", "dynamic"), |b| {
+        fluid_let!(static COUNTER: i32);
+        let mut total = 0;
+        b.iter(|| COUNTER.set(total, || black_box(total += total)));
+    });
+    group.bench_function(BenchmarkId::new("set", "static"), |b| {
+        static mut COUNTER: Option<&i32> = None;
+        let mut total = 0;
+        b.iter(|| unsafe {
+            // It's safe to transmute reference lifetime like this:
+            COUNTER = Some(std::mem::transmute(&total));
+            black_box(total += total);
+            COUNTER = None;
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(fluid_let, get, set);
+
+criterion_main!(fluid_let);

--- a/benches/fluid-let.rs
+++ b/benches/fluid-let.rs
@@ -31,7 +31,7 @@ fn set(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("set", "dynamic"), |b| {
         fluid_let!(static COUNTER: i32);
         let mut total = 0;
-        b.iter(|| COUNTER.set(total, || black_box(total += total)));
+        b.iter(|| COUNTER.set(total, || total += total));
     });
     group.bench_function(BenchmarkId::new("set", "static"), |b| {
         static mut COUNTER: Option<&i32> = None;
@@ -39,7 +39,8 @@ fn set(c: &mut Criterion) {
         b.iter(|| unsafe {
             // It's safe to transmute reference lifetime like this:
             COUNTER = Some(std::mem::transmute(&total));
-            black_box(total += total);
+            total += total;
+            black_box(());
             COUNTER = None;
         });
     });


### PR DESCRIPTION
Add some primitive benchmarks for variable access. I came to like the criterion microbenchmarking framework so let's use it. Since the crate does not have much API surface to cover, we measure the overhead for accessing a dynamic variable for reading and writing. Difference between the benchmarks for static and dynamic is the overhead spent on thread-local storage and all that's in-between.

The overhead turns out to be relatively small: around 5 nanoseconds on my machine. However, it is also quite large in the perspective: static variable access takes about 0.5 nanoseconds, therefore dynamic variables introduce about x10 slowdown.

Improves on issue #2