### PR TITLE
More accurate benchmarks

### DIFF
--- a/benches/fluid-let.rs
+++ b/benches/fluid-let.rs
@@ -5,13 +5,24 @@ use criterion::*;
 
 use fluid_let::fluid_let;
 
+#[inline]
+fn read_and_add(sum: &mut i32, value: &i32) {
+    // Make sure the compiler does not optimize this and emits actual loads & stores.
+    // This is safe since we convert valid Rust references to pointers here.
+    unsafe {
+        let a = std::ptr::read_volatile(sum);
+        let b = std::ptr::read_volatile(value);
+        std::ptr::write_volatile(sum, a + b);
+    }
+}
+
 fn get(c: &mut Criterion) {
     let mut group = c.benchmark_group("fluid_let");
     group.bench_function(BenchmarkId::new("get", "dynamic"), |b| {
         fluid_let!(static COUNTER: i32);
         let mut total = 0;
         COUNTER.set(1, || {
-            b.iter(|| COUNTER.get(|value| total += value.unwrap_or(&0)));
+            b.iter(|| COUNTER.get(|value| read_and_add(&mut total, value.unwrap_or(&0))));
         });
     });
     group.bench_function(BenchmarkId::new("get", "static"), |b| {
@@ -19,7 +30,7 @@ fn get(c: &mut Criterion) {
         let mut total = 0;
         unsafe {
             COUNTER = Some(&1);
-            b.iter(|| total += COUNTER.unwrap_or(&0));
+            b.iter(|| read_and_add(&mut total, COUNTER.unwrap_or(&0)));
             COUNTER = None;
         }
     });
@@ -30,17 +41,17 @@ fn set(c: &mut Criterion) {
     let mut group = c.benchmark_group("fluid_let");
     group.bench_function(BenchmarkId::new("set", "dynamic"), |b| {
         fluid_let!(static COUNTER: i32);
+        static MAGIC_VALUE: i32 = 42;
         let mut total = 0;
-        b.iter(|| COUNTER.set(total, || total += total));
+        b.iter(|| COUNTER.set(&MAGIC_VALUE, || read_and_add(&mut total, &MAGIC_VALUE)));
     });
     group.bench_function(BenchmarkId::new("set", "static"), |b| {
         static mut COUNTER: Option<&i32> = None;
+        static MAGIC_VALUE: i32 = 42;
         let mut total = 0;
         b.iter(|| unsafe {
-            // It's safe to transmute reference lifetime like this:
-            COUNTER = Some(std::mem::transmute(&total));
-            total += total;
-            black_box(());
+            COUNTER = Some(&MAGIC_VALUE);
+            read_and_add(&mut total, &MAGIC_VALUE);
             COUNTER = None;
         });
     });

--- a/benches/fluid-let.rs
+++ b/benches/fluid-let.rs
@@ -5,6 +5,7 @@ use criterion::*;
 
 use fluid_let::fluid_let;
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 #[inline]
 fn read_and_add(sum: &mut i32, value: &i32) {
     // Make sure the compiler does not optimize this and emits actual loads & stores.


### PR DESCRIPTION
Make sure that the compiler actually emits memory loads and stores in attempt to accurately measure the overhead of accessing dynamic variables. We'd like to make sure that the compiler outputs the same code in both cases (barring static/dynamic differences), and does not try to inline anything unnecessary or cache values in registers and optimize memory loads and stores.