### PR TITLE
More strict value setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 The version currently under development.
 
+Breaking changes:
+
+- `set()` now accepts only `&T` instead of `Borrow<T>`, avoiding implicit
+  temporary copies of types implementing `Copy`.
+
 Version 0.1.0 — 2019-03-12
 ==========================
 

--- a/benches/fluid-let.rs
+++ b/benches/fluid-let.rs
@@ -22,7 +22,7 @@ fn get(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("get", "dynamic"), |b| {
         fluid_let!(static COUNTER: i32);
         let mut total = 0;
-        COUNTER.set(1, || {
+        COUNTER.set(&1, || {
             b.iter(|| COUNTER.get(|value| read_and_add(&mut total, value.unwrap_or(&0))));
         });
     });

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -5,13 +5,13 @@ use std::thread;
 
 use fluid_let::fluid_let;
 
-fluid_let!(static YEAR: i32);
-
 #[test]
 fn dynamic_scoping() {
+    fluid_let!(static YEAR: i32);
+
     YEAR.get(|current| assert_eq!(current, None));
 
-    YEAR.set(2019, || {
+    YEAR.set(&2019, || {
         YEAR.get(|current| assert_eq!(current, Some(&2019)));
 
         YEAR.set(&2525, || {
@@ -21,32 +21,14 @@ fn dynamic_scoping() {
 }
 
 #[test]
-fn references() {
-    fn get_year() -> i32 {
-        YEAR.get(|value| *value.unwrap())
-    }
-
-    // Temporary value
-    YEAR.set(10, || assert_eq!(get_year(), 10));
-
-    // Local reference
-    let current_year = 20;
-    YEAR.set(&current_year, || assert_eq!(get_year(), 20));
-
-    // Heap reference
-    let current_year = Box::new(30);
-    YEAR.set(current_year, || assert_eq!(get_year(), 30));
-}
-
-fluid_let!(static THREAD_ID: i8);
-
-#[test]
 fn thread_locality() {
-    THREAD_ID.set(0, || {
+    fluid_let!(static THREAD_ID: i8);
+
+    THREAD_ID.set(&0, || {
         THREAD_ID.get(|current| assert_eq!(current, Some(&0)));
         let t = thread::spawn(move || {
             THREAD_ID.get(|current| assert_eq!(current, None));
-            THREAD_ID.set(1, || {
+            THREAD_ID.set(&1, || {
                 THREAD_ID.get(|current| assert_eq!(current, Some(&1)));
             });
         });


### PR DESCRIPTION
Replace the trait bound on the **set()** method to be just reference instead of using `Borrow<T>` which allows either references or owned values. This is not really a security issue, but it has some weird readability issues with types that implement `Copy` (and those are most likely candidates for being used as dynamic variables). Using `Borrow<T>` allows the following:

```rust
#[test]
fn apparent_aliasing_violation() {
    fluid_let!(static VARIABLE: i32);

    let mut value = 0;
    VARIABLE.set(value, || {
        VARIABLE.get(|value_2| {
            VARIABLE.set(value_2.unwrap_or(&0), || {
                VARIABLE.get(|value_3| {
                    value = 10;
                    assert_eq!(value_3, Some(&10));
                    // actually assetion fails, value_3 == 0
                })
            });
        });
    });
}
```

which *looks like* a violation of Rust aliasing rules, but actually it isn't. It seems that you can assign new value to the original `value` while still having references to it inside get() calls, but that's not what's happening here. You actually assign to an implicit temporary copy of the `value` made in the first set() call.

Let's deny this and require the user to explicitly pass a reference. This way we don't introduce any ambiguity and the compiler will warn about actual aliasing violations where you do try to assign to the variable you use for dynamic value.

While we're here, make miscellaneous updates to the documentation to make it clear what guarantees we provide and how to use dynamic variables. And clean up terminology a bit.