### PR TITLE
Convenience accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking changes:
 New features:
 
 - Convenience getters `copied()` and `cloned()` for copyable types.
+- Convenience setter `fluid_set!` for scoped assignment.
 
 Version 0.1.0 — 2019-03-12
 ==========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Breaking changes:
 - `set()` now accepts only `&T` instead of `Borrow<T>`, avoiding implicit
   temporary copies of types implementing `Copy`.
 
+New features:
+
+- Convenience getters `copied()` and `cloned()` for copyable types.
+
 Version 0.1.0 — 2019-03-12
 ==========================
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,14 @@
 //! You can’t directly modify the dynamic variable value after setting it,
 //! but you can use something like `Cell` or `RefCell` to circumvent that.
 //!
-//! The new value is in effect within the _dynamic extent_ of the assignment, that is within
-//! the closure passed to `set`. Once the closure returns, the previous value of the variable
-//! is restored. You can nest assignments arbitrarily:
+//! The new value is in effect within the _dynamic extent_ of the assignment,
+//! that is within the closure passed to `set`. Once the closure returns, the
+//! previous value of the variable is restored.
+//!
+//! If you do not need precise control over the extent of the assignment, you
+//! can use the [`fluid_set!`] macro to assign until the end of the scope:
+//!
+//! [`fluid_set!`]: macro.fluid_set.html
 //!
 //! ```no_run
 //! # use std::fs::File;
@@ -66,18 +71,40 @@
 //! #
 //! # fn open(path: &str) -> File { unimplemented!() }
 //! #
-//! LOG_FILE.set(&open("/tmp/log.txt"), || {
+//! use fluid_let::fluid_set;
+//!
+//! fn chatterbox_function() {
+//!     fluid_set!(LOG_FILE, &open("/dev/null"));
 //!     //
-//!     // log to /tmp/log.txt here
+//!     // logs will be written to /dev/null in this function
 //!     //
+//! }
+//! ```
+//!
+//! Obviously, you can also nest assignments arbitrarily:
+//!
+//! ```no_run
+//! # use std::fs::File;
+//! #
+//! # use fluid_let::{fluid_let, fluid_set};
+//! #
+//! # fluid_let!(static LOG_FILE: File);
+//! #
+//! # fn open(path: &str) -> File { unimplemented!() }
+//! #
+//! LOG_FILE.set(&open("A.txt"), || {
+//!     // log to A.txt here
 //!     LOG_FILE.set(&open("/dev/null"), || {
-//!         //
 //!         // log to /dev/null for a bit
-//!         //
+//!         fluid_set!(LOG_FILE, &open("B.txt"));
+//!         // log to B.txt starting with this line
+//!         {
+//!             fluid_set!(LOG_FILE, &open("C.txt"));
+//!             // but in this block log to C.txt
+//!         }
+//!         // before going back to using B.txt here
 //!     });
-//!     //
-//!     // log to /tmp/log.txt again
-//!     //
+//!     // and logging to A.txt again
 //! });
 //! ```
 //!
@@ -227,6 +254,49 @@ macro_rules! fluid_let {
     {} => {};
 }
 
+/// Binds a value to a dynamic variable.
+///
+/// # Examples
+///
+/// If you do not need to explicitly delimit the scope of dynamic assignment then you can
+/// use `fluid_set!` to assign a value until the end of the current scope:
+///
+/// ```no_run
+/// use fluid_let::{fluid_let, fluid_set};
+///
+/// fluid_let!(static ENABLED: bool);
+///
+/// fn some_function() {
+///     fluid_set!(ENABLED, &true);
+///
+///     // function body
+/// }
+/// ```
+///
+/// This is effectively equivalent to writing
+///
+/// ```no_run
+/// # use fluid_let::{fluid_let, fluid_set};
+/// #
+/// # fluid_let!(static ENABLED: bool);
+/// #
+/// fn some_function() {
+///     ENABLED.set(&true, || {
+///         // function body
+///     });
+/// }
+/// ```
+///
+/// See also [crate-level documentation](index.html) for usage examples.
+#[macro_export]
+macro_rules! fluid_set {
+    ($variable:expr, $value:expr) => {
+        // This is safe because the users do not get direct access to the guard
+        // and are not able to drop it prematurely, thus maintaining invariants.
+        let guard = unsafe { $variable.set_guard($value) };
+    };
+}
+
 /// A global dynamic variable.
 ///
 /// Declared and initialized by the [`fluid_let!`](macro.fluid_let.html) macro.
@@ -266,6 +336,22 @@ impl<T> DynamicVariable<T> {
             let _guard = unsafe { current.set(value) };
             f()
         })
+    }
+
+    /// Bind a new value to the dynamic variable.
+    ///
+    /// # Safety
+    ///
+    /// The value is bound for the lifetime of the returned guard. The guard must be
+    /// dropped before the end of lifetime of the new and old assignment values.
+    /// If the variable is assigned another value while this guard is alive, it must
+    /// not be dropped until that new assignment is undone.
+    #[doc(hidden)]
+    pub unsafe fn set_guard(&self, value: &T) -> DynamicCellGuard<T> {
+        use std::mem::transmute;
+        // We use transmute to extend the lifetime or "current" to that of "value".
+        // This is really the case when assignments are properly scoped.
+        self.cell.with(|current| transmute(current.set(value)))
     }
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -3,7 +3,7 @@
 
 use std::thread;
 
-use fluid_let::fluid_let;
+use fluid_let::{fluid_let, fluid_set};
 
 #[test]
 fn dynamic_scoping() {
@@ -11,13 +11,15 @@ fn dynamic_scoping() {
 
     YEAR.get(|current| assert_eq!(current, None));
 
-    YEAR.set(&2019, || {
-        YEAR.get(|current| assert_eq!(current, Some(&2019)));
+    fluid_set!(YEAR, &2019);
 
-        YEAR.set(&2525, || {
-            YEAR.get(|current| assert_eq!(current, Some(&2525)));
-        })
-    });
+    YEAR.get(|current| assert_eq!(current, Some(&2019)));
+    {
+        fluid_set!(YEAR, &2525);
+
+        YEAR.get(|current| assert_eq!(current, Some(&2525)));
+    }
+    YEAR.get(|current| assert_eq!(current, Some(&2019)));
 }
 
 #[test]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -45,3 +45,14 @@ fluid_let! {
     /// Variable 3
     pub static VAR_3: u8;
 }
+
+#[test]
+fn convenience_accessors() {
+    fluid_let!(static ENABLED: bool);
+
+    assert_eq!(ENABLED.cloned(), None);
+    assert_eq!(ENABLED.copied(), None);
+
+    ENABLED.set(&true, || assert_eq!(ENABLED.cloned(), Some(true)));
+    ENABLED.set(&true, || assert_eq!(ENABLED.copied(), Some(true)));
+}


### PR DESCRIPTION
Often dynamic variables are used for simple values like boolean flags or integer values. In this case we do not really need to use the weird closure-based accessor mechanism and are totally fine with a quick copy.

Provide **copied()** and **cloned()** accessors similar to `Option<T>` methods which copy and clone the inner Option value.

It turns out that Rust macros are actually splicing so we are able to write a macro that make scoped assignments easier. Normally, this is what users would probably do.

Introduce a **fluid_set!** macro which can reduce the amount of nesting and acts as a scoped RAII-style guard for binding dynamic variables.

Closes #3