### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluid-let"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["ilammy"]
 edition = "2018"
 description = "Dynamically-scoped variables"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-fluid-let = "0.1.0"
+fluid-let = "1.0"
 ```
 
 You can declare global dynamic variables using `fluid_let!` macro.


### PR DESCRIPTION
Actually, you know what? I’m pretty confident that this is the API that I want to use, so let’s be bold and go for stabilizing. It’s semver after all, I can always go and put out 2.0 if I find that some APIs have to be broken. It’s not like I’m going to piss off «the community» by doing this, lol.