### PR TITLE
Run apt-get update before installing deps

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         toolchain: stable
     - name: Set up gnuplot
-      run: sudo apt-get install gnuplot
+      run: sudo apt-get update && sudo apt-get install gnuplot
 
     - name: Check out old code
       uses: actions/checkout@v1


### PR DESCRIPTION
The image might be running outdated APT databases. Let’s update them before trying to install anything. In this case we only need **gnuplot**.

This has been breaking builds with unrelated errors.