### PR TITLE
Allow owned setters once again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,6 @@
 
 The version currently under development.
 
-Breaking changes:
-
-- `set()` now accepts only `&T` instead of `Borrow<T>`, avoiding implicit
-  temporary copies of types implementing `Copy`.
-
 New features:
 
 - Convenience getters `copied()` and `cloned()` for copyable types.

--- a/benches/fluid-let.rs
+++ b/benches/fluid-let.rs
@@ -22,7 +22,7 @@ fn get(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("get", "dynamic"), |b| {
         fluid_let!(static COUNTER: i32);
         let mut total = 0;
-        COUNTER.set(&1, || {
+        COUNTER.set(1, || {
             b.iter(|| COUNTER.get(|value| read_and_add(&mut total, value.unwrap_or(&0))));
         });
     });
@@ -44,7 +44,7 @@ fn set(c: &mut Criterion) {
         fluid_let!(static COUNTER: i32);
         static MAGIC_VALUE: i32 = 42;
         let mut total = 0;
-        b.iter(|| COUNTER.set(&MAGIC_VALUE, || read_and_add(&mut total, &MAGIC_VALUE)));
+        b.iter(|| COUNTER.set(MAGIC_VALUE, || read_and_add(&mut total, &MAGIC_VALUE)));
     });
     group.bench_function(BenchmarkId::new("set", "static"), |b| {
         static mut COUNTER: Option<&i32> = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,8 @@ impl<T> DynamicVariable<T> {
         unsafe fn extend_lifetime<'a, 'b, T>(r: &'a T) -> &'b T {
             mem::transmute(r)
         }
-        self.cell.with(|current| extend_lifetime(current).set(value))
+        self.cell
+            .with(|current| extend_lifetime(current).set(value))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! #
 //! # enum LogLevel { Info }
 //! #
-//! fluid_let!(static LOG_LEVEL: LogLevel = &LogLevel::Info);
+//! fluid_let!(static LOG_LEVEL: LogLevel = LogLevel::Info);
 //! ```
 //!
 //! Here `LOG_LEVEL` has `Some(&LogLevel::Info)` as its default value.
@@ -55,7 +55,7 @@
 //! #
 //! let log_file: File = open("/tmp/log.txt");
 //!
-//! LOG_FILE.set(&log_file, || {
+//! LOG_FILE.set(log_file, || {
 //!     //
 //!     // logs will be redirected to /tmp/log.txt in this block
 //!     //
@@ -87,7 +87,7 @@
 //! use fluid_let::fluid_set;
 //!
 //! fn chatterbox_function() {
-//!     fluid_set!(LOG_FILE, &open("/dev/null"));
+//!     fluid_set!(LOG_FILE, open("/dev/null"));
 //!     //
 //!     // logs will be written to /dev/null in this function
 //!     //
@@ -105,14 +105,14 @@
 //! #
 //! # fn open(path: &str) -> File { unimplemented!() }
 //! #
-//! LOG_FILE.set(&open("A.txt"), || {
+//! LOG_FILE.set(open("A.txt"), || {
 //!     // log to A.txt here
-//!     LOG_FILE.set(&open("/dev/null"), || {
+//!     LOG_FILE.set(open("/dev/null"), || {
 //!         // log to /dev/null for a bit
-//!         fluid_set!(LOG_FILE, &open("B.txt"));
+//!         fluid_set!(LOG_FILE, open("B.txt"));
 //!         // log to B.txt starting with this line
 //!         {
-//!             fluid_set!(LOG_FILE, &open("C.txt"));
+//!             fluid_set!(LOG_FILE, open("C.txt"));
 //!             // but in this block log to C.txt
 //!         }
 //!         // before going back to using B.txt here
@@ -209,6 +209,7 @@
 //! In this case you will probably need some synchronization to use the shared
 //! object in a safe manner, just like you would do when using `Arc` and friends.
 
+use std::borrow::Borrow;
 use std::cell::UnsafeCell;
 use std::mem;
 use std::thread::LocalKey;
@@ -221,7 +222,7 @@ use std::thread::LocalKey;
 ///
 /// ```
 /// # use fluid_let::fluid_let;
-/// fluid_let!(static ENABLED: bool = &true);
+/// fluid_let!(static ENABLED: bool = true);
 /// ```
 ///
 /// Default value is optional:
@@ -237,7 +238,7 @@ use std::thread::LocalKey;
 /// # use fluid_let::fluid_let;
 /// fluid_let! {
 ///     /// Length of `Debug` representation of hashes in characters.
-///     pub static HASH_LENGTH: usize = &32;
+///     pub static HASH_LENGTH: usize = 32;
 ///
 ///     /// If set to true then passwords will be printed to logs.
 ///     #[cfg(test)]
@@ -268,8 +269,9 @@ macro_rules! fluid_let {
     } => {
         $(#[$attr])*
         $v static $name: $crate::DynamicVariable<$type_> = {
+            static DEFAULT: $type_ = $value;
             thread_local! {
-                static VARIABLE: $crate::DynamicCell<$type_> = $crate::DynamicCell::with_static($value);
+                static VARIABLE: $crate::DynamicCell<$type_> = $crate::DynamicCell::with_static(&DEFAULT);
             }
             $crate::DynamicVariable { cell: &VARIABLE }
         };
@@ -333,9 +335,10 @@ macro_rules! fluid_let {
 #[macro_export]
 macro_rules! fluid_set {
     ($variable:expr, $value:expr) => {
+        let _value_ = $value;
         // This is safe because the users do not get direct access to the guard
         // and are not able to drop it prematurely, thus maintaining invariants.
-        let _guard_ = unsafe { $variable.set_guard($value) };
+        let _guard_ = unsafe { $variable.set_guard(&_value_) };
     };
 }
 
@@ -374,11 +377,11 @@ impl<T> DynamicVariable<T> {
     }
 
     /// Bind a new value to the dynamic variable.
-    pub fn set<R>(&self, value: &T, f: impl FnOnce() -> R) -> R {
+    pub fn set<R>(&self, value: impl Borrow<T>, f: impl FnOnce() -> R) -> R {
         self.cell.with(|current| {
             // This is safe because the guard returned by set() is guaranteed to be
             // dropped after the thunk returns and before anything else executes.
-            let _guard_ = unsafe { current.set(value) };
+            let _guard_ = unsafe { current.set(value.borrow()) };
             f()
         })
     }
@@ -395,7 +398,10 @@ impl<T> DynamicVariable<T> {
     pub unsafe fn set_guard(&self, value: &T) -> DynamicCellGuard<T> {
         // We use transmute to extend the lifetime or "current" to that of "value".
         // This is really the case when assignments are properly scoped.
-        self.cell.with(|current| mem::transmute(current.set(value)))
+        unsafe fn extend_lifetime<'a, 'b, T>(r: &'a T) -> &'b T {
+            mem::transmute(r)
+        }
+        self.cell.with(|current| extend_lifetime(current).set(value))
     }
 }
 
@@ -515,14 +521,14 @@ mod tests {
 
     #[test]
     fn static_initializer() {
-        fluid_let!(static NUMBER: i32 = &42);
+        fluid_let!(static NUMBER: i32 = 42);
 
         assert_eq!(NUMBER.copied(), Some(42));
 
         fluid_let! {
-            static NUMBER_1: i32 = &100;
+            static NUMBER_1: i32 = 100;
             static NUMBER_2: i32;
-            static NUMBER_3: i32 = &200;
+            static NUMBER_3: i32 = 200;
         }
 
         assert_eq!(NUMBER_1.copied(), Some(100));
@@ -536,11 +542,11 @@ mod tests {
 
         YEAR.get(|current| assert_eq!(current, None));
 
-        fluid_set!(YEAR, &2019);
+        fluid_set!(YEAR, 2019);
 
         YEAR.get(|current| assert_eq!(current, Some(&2019)));
         {
-            fluid_set!(YEAR, &2525);
+            fluid_set!(YEAR, 2525);
 
             YEAR.get(|current| assert_eq!(current, Some(&2525)));
         }
@@ -548,14 +554,33 @@ mod tests {
     }
 
     #[test]
+    fn references() {
+        fluid_let!(static YEAR: i32);
+
+        // Temporary value
+        fluid_set!(YEAR, 10);
+        assert_eq!(YEAR.copied(), Some(10));
+
+        // Local reference
+        let current_year = 20;
+        fluid_set!(YEAR, &current_year);
+        assert_eq!(YEAR.copied(), Some(20));
+
+        // Heap reference
+        let current_year = Box::new(30);
+        fluid_set!(YEAR, current_year);
+        assert_eq!(YEAR.copied(), Some(30));
+    }
+
+    #[test]
     fn thread_locality() {
         fluid_let!(static THREAD_ID: i8);
 
-        THREAD_ID.set(&0, || {
+        THREAD_ID.set(0, || {
             THREAD_ID.get(|current| assert_eq!(current, Some(&0)));
             let t = thread::spawn(move || {
                 THREAD_ID.get(|current| assert_eq!(current, None));
-                THREAD_ID.set(&1, || {
+                THREAD_ID.set(1, || {
                     THREAD_ID.get(|current| assert_eq!(current, Some(&1)));
                 });
             });
@@ -570,8 +595,8 @@ mod tests {
         assert_eq!(ENABLED.cloned(), None);
         assert_eq!(ENABLED.copied(), None);
 
-        ENABLED.set(&true, || assert_eq!(ENABLED.cloned(), Some(true)));
-        ENABLED.set(&true, || assert_eq!(ENABLED.copied(), Some(true)));
+        ENABLED.set(true, || assert_eq!(ENABLED.cloned(), Some(true)));
+        ENABLED.set(true, || assert_eq!(ENABLED.copied(), Some(true)));
     }
 
     struct Hash {
@@ -603,7 +628,7 @@ mod tests {
     fn readme_example_code() {
         let hash = Hash { value: [0; 16] };
         assert_eq!(format!("{:?}", hash), "Hash(00000000...)");
-        fluid_set!(DEBUG_FULL_HASH, &true);
+        fluid_set!(DEBUG_FULL_HASH, true);
         assert_eq!(
             format!("{:?}", hash),
             "Hash(00000000000000000000000000000000)"


### PR DESCRIPTION
This reverts #8.

Partially revert the changes from that commit, bringing back setting value through `Borrow<T>`. I have finally realized the background for this feature. It allows efficient setting of value types, without all these unnecessary references in initializer expressions.

Yeah, it does make it weird when "Copy" types get passed into set(), but honestly it's just weird to expect that capturing behavior to be used in the wild. Normally you don't combine set() and get() for the same variable in one piece of code. If you do then why not just use regular variables where static scoping works just fine?

Note that DynamicCell::set_guard() still accepts a reference to some local variable, and DynamicCell::with_static() still initializes the cell with a reference to static object. This is really important for memory safety. We cannot make the guard own the value set because the guard can be moved around and to allow that we'll need to pin the set value somehow. "Pinning" it in static memory or on the stack is the most efficient way.