### PR TITLE
Assign back the old value directly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,7 +468,7 @@ impl<'a, T> Drop for DynamicCellGuard<'a, T> {
         // get() and set() methods of DynamicCell are used correctly. That is, there must be
         // no users of the new value which is about to be destroyed.
         unsafe {
-            mem::replace(&mut *self.cell.cell.get(), self.old_value.take());
+            *self.cell.cell.get() = self.old_value.take();
         }
     }
 }


### PR DESCRIPTION
New Clippy is more vigilant, complaining that I drop the new value implicitly. Replace `mem::replace()` with just assignment to make it clear that the value is replaced and dropped.