### PR TITLE
Gate static initialization behind `"static-init"` feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,18 @@ jobs:
     - name: Check code formatting
       run: cargo fmt -- --check
     - name: Run static analysis
-      run: cargo clippy
+      run: |
+        cargo clippy
+        cargo clippy --features static-init
     - name: Run normal build
-      run: cargo build
+      run: |
+        cargo build
+        cargo build --features static-init
     - name: Run static analysis on tests
-      run: cargo clippy --all-targets
+      run: |
+        cargo clippy --all-targets
+        cargo clippy --all-targets --features static-init
     - name: Run unit-test suite
-      run: cargo test
+      run: |
+        cargo test
+        cargo test --features static-init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,6 @@ jobs:
       run: cargo clippy
     - name: Run normal build
       run: cargo build
-    - name: Compile testing dependencies
-      run: cargo test --no-run
     - name: Run static analysis on tests
       run: cargo clippy --all-targets
     - name: Run unit-test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ New features:
 
 - Convenience getters `copied()` and `cloned()` for copyable types.
 - Convenience setter `fluid_set!` for scoped assignment.
-- `fluid_let!` now allows `'static` initializers.
+
+Unstable features:
+
+- `"static-init"` Cargo feature
+  - `fluid_let!` allows `'static` initializers:
+    ```rust
+    fluid_let!(static VARIABLE: Type = initial_value);
+    ```
 
 Version 0.1.0 — 2019-03-12
 ==========================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT"
 
 [features]
 static-init = []
+
+[package.metadata.docs.rs]
+features = [ "static-init" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ readme = "README.md"
 keywords = ["dynamic", "fluid", "scope", "variables"]
 categories = ["config"]
 license = "MIT"
+
+[features]
+static-init = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,23 @@
 //! internal mutability to a dynamic variable and access it from multiple threads.
 //! In this case you will probably need some synchronization to use the shared
 //! object in a safe manner, just like you would do when using `Arc` and friends.
+//!
+//! # Features
+//!
+//! Currently, there is only one optional feature: `"static-init"`,
+//! gating static initialization of dynamic variables:
+//!
+//! ```
+//! # use fluid_let::fluid_let;
+//! #
+//! # enum LogLevel { Info }
+//! #
+//! fluid_let!(static LOG_LEVEL: LogLevel = LogLevel::Info);
+//! //                                    ~~~~~~~~~~~~~~~~
+//! ```
+//!
+//! The API for accessing known-initialized variables has not stabilized yet
+//! and may be subject to changes.
 
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //! #
 //! # enum LogLevel { Info }
 //! #
+//! # #[cfg(feature = "static-init")]
 //! fluid_let!(static LOG_LEVEL: LogLevel = LogLevel::Info);
 //! ```
 //!
@@ -219,6 +220,7 @@
 //! #
 //! # enum LogLevel { Info }
 //! #
+//! # #[cfg(feature = "static-init")]
 //! fluid_let!(static LOG_LEVEL: LogLevel = LogLevel::Info);
 //! //                                    ~~~~~~~~~~~~~~~~
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@
 //! possibly absent reference to a file. All dynamic variables have `None` as
 //! their default value, unless a particular value is set for them.
 //!
-//! It is also possible to provide `'static` initialization, if variable type
-//! allows it:
+//! If you enable the [`"static-init"` feature](#features), it is also
+//! possible to provide `'static` initialization for types that allow it:
 //!
 //! ```no_run
 //! # use fluid_let::fluid_let;
@@ -240,14 +240,15 @@ use std::thread::LocalKey;
 ///
 /// ```
 /// # use fluid_let::fluid_let;
-/// fluid_let!(static ENABLED: bool = true);
+/// fluid_let!(static ENABLED: bool);
 /// ```
 ///
-/// Default value is optional:
+/// If [`"static-init"` feature](index.html#features) is enabled,
+/// you can provide initial value:
 ///
 /// ```
 /// # use fluid_let::fluid_let;
-/// fluid_let!(static ENABLED: bool);
+/// fluid_let!(static ENABLED: bool = true);
 /// ```
 ///
 /// Multiple declarations with attributes and visibility modifiers are also supported:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,6 +436,7 @@ impl<T> DynamicCell<T> {
     }
 
     /// Makes a new cell with value.
+    #[cfg(feature = "static-init")]
     pub fn with_static(value: &'static T) -> Self {
         DynamicCell {
             cell: UnsafeCell::new(Some(value)),
@@ -528,6 +529,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "static-init")]
     fn static_initializer() {
         fluid_let!(static NUMBER: i32 = 42);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,16 +175,13 @@
 //!     Error,
 //! }
 //!
-//! fluid_let!(static MIN_LOG_LEVEL: LogLevel);
-//!
-//! const DEFAULT_MIN_LOG_LEVEL: LogLevel = LogLevel::Info;
-//!
-//! fn min_log_level() -> LogLevel {
-//!     MIN_LOG_LEVEL.copied().unwrap_or(DEFAULT_MIN_LOG_LEVEL)
-//! }
+//! # #[cfg(not(feature = "fluid-let"))]
+//! # fluid_let!(static LOG_LEVEL: LogLevel);
+//! # #[cfg(feature = "fluid-let")]
+//! fluid_let!(static LOG_LEVEL: LogLevel = LogLevel::Info);
 //!
 //! fn write_log(level: LogLevel, msg: &str) -> io::Result<()> {
-//!     if level < min_log_level() {
+//!     if level < LOG_LEVEL.copied().unwrap() {
 //!         return Ok(());
 //!     }
 //!     LOG_FILE.get(|current| {


### PR DESCRIPTION
People are craving the 1.0.0 release but I don't have static initialization ready – at least, API-wise. Let's hide this thing behind a feature flag.

You will need to import the crate like this:

```toml
[dependencies]
fluid-let = { version = "1", features = ["static-init"] }
```

in order to enable static initialization syntax:

```rust
fluid_let!(static VARIABLE: Type = initial_value);
```

I reserve the right to push breaking changes into anything behind this flag, and to remove the flag without a major version bump. Code that uses default features is considered stable and I would feel bad for breaking it. But not with this feature.

In the future, the `get()` method on dynamic variables with known initial value will likely return `&T` directly instead of wrapping it into `Option<&T>`. That is, as soon as I figure out how to do that...